### PR TITLE
fix: add pre-refresh hook to set port if unset

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -6,7 +6,7 @@ new_port="$(snapctl get port)"
 # Validate it
 if ! expr "$new_port" : '^[1-9][0-9]*$' > /dev/null; then
     echo "\"$new_port\" is not a valid port number" >&2
-	exit 1
+    exit 1
 fi
 
 snapctl restart qr-server

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -1,0 +1,16 @@
+#!/bin/sh -e
+
+# Check if port value is currently unset, and if so, set to 5000.
+#
+# On a fresh install, the install hook should set the port to the default
+# value, but if we're refreshing from a version which does not support a
+# configurable port to one which does, the install hook does not run, so the
+# configure hook would see the empty port setting and fail, reverting the
+# refresh. To avoid this, ensure that before the refresh occurs, a port is set,
+# so the configure hook triggered by the refresh will succeed as well.
+
+port="$(snapctl get port)"
+
+if [ -z "$port" ]; then
+    snapctl set port=5000
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: qr-server
 base: core24
-version: '0.2'
+version: '0.2.1'
 summary: A server to generate QR codes
 description: |
   Listen on a port and serve QR codes encoding the data after the hostname.


### PR DESCRIPTION
On a fresh install, the install hook set a default port (5000), but on a refresh from a version without configurable port to a version with configurable port, the configure hook would throw an error because the configuration value for the port was unset, causing the refresh to fail.

By adding a pre-refresh hook, we ensure that there is a port set prior to the configure hook, so the refresh can succeed.