### PR TITLE
fix: move pre-refresh hook to post-refresh so the new revision sets the port

### DIFF
--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -6,8 +6,9 @@
 # value, but if we're refreshing from a version which does not support a
 # configurable port to one which does, the install hook does not run, so the
 # configure hook would see the empty port setting and fail, reverting the
-# refresh. To avoid this, ensure that before the refresh occurs, a port is set,
-# so the configure hook triggered by the refresh will succeed as well.
+# refresh. To avoid this, ensure that after the refresh occurs, a port is set
+# for the new revision so the configure hook triggered by the refresh will
+# succeed as well.
 
 port="$(snapctl get port)"
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: qr-server
 base: core24
-version: '0.2.1'
+version: '0.2.2'
 summary: A server to generate QR codes
 description: |
   Listen on a port and serve QR codes encoding the data after the hostname.


### PR DESCRIPTION
The pre-refresh hook executes on the existing revision, which inconveniently does not have the pre-refresh hook yet set, so the refresh fails when refreshing from a revision without support for a configurable port. What we really need is for the new revision to have a port set prior to the configure hook, so do so in the post-refresh hook, which is run with the new snap revision.