### PR TITLE
Feat: support using request body as data if path is omitted

### DIFF
--- a/bin/qr_server.py
+++ b/bin/qr_server.py
@@ -20,16 +20,16 @@ app = flask.Flask(__name__)
 app.config['MAX_CONTENT_LENGTH'] = 2953
 
 @app.route('/', methods=['GET', 'POST'])
-def home():
-    args = ['qrencode', '--output', '-', '--size', '10', '--margin', '2']
+def render_body_as_qr():
     data = flask.request.get_data(cache=False)
     if len(data) == 0:
-        return f'Please include data in the request body or following the slash after the hostname[:port]'
+        return 'Please include data in the request body or following the slash after the hostname[:port]', 400
+    args = ['qrencode', '--output', '-', '--size', '10', '--margin', '2']
     proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
     io_result = io.BytesIO(proc.communicate(input=data)[0])
     return flask.send_file(io_result, mimetype='image/png')
 
-@app.route('/<path:path>')
+@app.route('/<path:path>', methods=['GET', 'POST'])
 def render_path_as_qr(path):
     args = ['qrencode', '--output', '-', '--size', '10', '--margin', '2', path]
     proc = subprocess.Popen(args, stdout=subprocess.PIPE)

--- a/bin/qr_server.py
+++ b/bin/qr_server.py
@@ -6,11 +6,12 @@
 
     A simple server to generate QR codes for data following the / in the URL.
 '''
-import sys
 import argparse
 import flask
-import subprocess
 import io
+import os
+import subprocess
+import sys
 
 app = flask.Flask(__name__)
 
@@ -26,8 +27,12 @@ def render_path_as_qr(path):
     return flask.send_file(io_result, mimetype='image/png')
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser('A simple server to generate QR codes, built using Flask and qrencode.')
+    parser = argparse.ArgumentParser(
+            prog=os.path.basename(sys.argv[0]),
+            description='A simple server to generate QR codes, built using Flask and qrencode.')
     parser.add_argument('host', help='the host on which this application is running')
     parser.add_argument('port', type=int, help='the port on which this application is listening')
+    parser.add_argument('--max-content-length', type=int, default=100, help='the maximum content length in request bodies, in MiB')
     arguments = parser.parse_args()
+    app.config['MAX_CONTENT_LENGTH'] = arguments.max_content_length * 1024 * 1024
     app.run(host=arguments.host, port=arguments.port)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: qr-server
 base: core24
-version: '0.2.3'
+version: '0.3.0'
 summary: A server to generate QR codes
 description: |
   Listen on a port and serve QR codes encoding data from the path or the

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,18 +3,24 @@ base: core24
 version: '0.2.3'
 summary: A server to generate QR codes
 description: |
-  Listen on a port and serve QR codes encoding the data after the hostname.
-  For example, if running on localhost, then http://localhost:5000/hello-there
-  will create a QR code encoding the string hello-there.
+  Listen on a port and serve QR codes encoding data from the path or the
+  request body.
 
-  Alternatively, the request body can be used as the data to encode by omitting
-  the path following the hostname. Both GET And POST requests are accepted.
-  For example: `curl -d 'some longer data' http://localhost:5000` will return a
-  QR code encoding "some longer data".
+  For example, if running on localhost and port 5000, then both of the
+  following are supported ways to generate a QR code encoding the string
+  "hello-there":
+
+  - `curl http://localhost:5000/hello-there`
+  - `curl -d 'hello-there' http://localhost:5000`
+
+  If the path following the hostname is non-empty, that will be used as the
+  data to encode, and the request body will be ignored.
 
   By default, listens on port 5000. To listen on another port, use
   `sudo snap set qr-server port=<port>`, with `<port>` being any available
   port number.
+
+  Both GET and POST requests are accepted and may be used interchangeably.
 
 title: QR Server
 icon: icon.png

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,6 +7,11 @@ description: |
   For example, if running on localhost, then http://localhost:5000/hello-there
   will create a QR code encoding the string hello-there.
 
+  Alternatively, the request body can be used as the data to encode by omitting
+  the path following the hostname. Both GET And POST requests are accepted.
+  For example: `curl -d 'some longer data' http://localhost:5000` will return a
+  QR code encoding "some longer data".
+
   By default, listens on port 5000. To listen on another port, use
   `sudo snap set qr-server port=<port>`, with `<port>` being any available
   port number.


### PR DESCRIPTION
So that longer data or data with special characters can be passed into the QR server, support reading data from the request body instead of the path. Both `GET` and `POST` requests are supported. If the URL has no path following the hostname, the request content is used, otherwise it is ignored and the path is used as the data in the QR code.